### PR TITLE
Feature/18 add inverse solution scripts

### DIFF
--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -73,10 +73,7 @@ def CalculateReflectanceVsWavelengthFromChromophoreConcAndScatterer(
    modelDataLocal=np.concatenate(
         [np.array(forwardSolver.ROfFx(opsLocal, fxs[0]), dtype=float), 
          np.array(forwardSolver.ROfFx(opsLocal, fxs[1]), dtype=float)])
-   modelDataForReturn=Array.CreateInstance(float, len(wavelengths)*len(fxs))
-   for i in range(0, len(fxs)*len(wavelengths)-1):
-        modelDataForReturn[i] = modelDataLocal[i]
-   return modelDataForReturn
+   return modelDataLocal
 
 # func for residual
 def residual(valuesSought, wavelengths, fxs, measuredROfFx, forwardSolver):

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -67,6 +67,8 @@ def CalculateReflectanceVsWavelengthFromChromophoreConcAndScatterer(
    scattererLocal = PowerLawScatterer(valuesSought[2], valuesSought[3])
    # Compose local tissue to obtain optical properties
    opsLocal = Tissue(chromophoresLocal, scattererLocal, "", n=1.4).GetOpticalProperties(wavelengths)
+   print("iter:[Hb HbO2 A b]=[%5.3f %5.3f %5.3f %5.3f]" % (
+         valuesSought[0], valuesSought[1], valuesSought[2],valuesSought[3]))
    # Compute reflectance for local absorbers
    modelDataLocal=np.concatenate(
         [np.array(forwardSolver.ROfFx(opsLocal, fxs[0]), dtype=float), 
@@ -136,14 +138,15 @@ chart.update_layout( title="ROfFx (inverse solution for chromophore concentratio
 
 chart.show(renderer="browser")
 # output results
-print("Meas =    [%5.3f %5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2], measuredData[3]))
+print("Meas =    [%5.3f %5.3f %5.3f %5.3f]" % (
+                 measuredData[0], measuredData[1], measuredData[2], measuredData[3]))
 print("IG   =    [%5.3f %5.3f %5.3f %5.3f] Chi2=%5.3e" % (
                  initialGuess[0], initialGuess[1], initialGuess[2], initialGuess[3],
-                 np.dot(measuredROfFx,initialGuessROfFx)))
+                 np.dot(measuredROfFx-initialGuessROfFx,measuredROfFx-initialGuessROfFx)))
 print("Conv =    [%5.3f %5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit.x[0], fit.x[1], fit.x[2], fit.x[3],
-                 np.dot(measuredROfFx,fitROfFx)))
-print("error =   [%5.3f %5.3f %5.3f %5.3f]" % (
-                 abs((measuredData[0]-fit.x[0])/measuredData[0]),
-                 abs((measuredData[1]-fit.x[1])/measuredData[1]),
-                 abs((measuredData[2]-fit.x[2])/measuredData[2]),
-                 abs((measuredData[3]-fit.x[3])/measuredData[3])))
+                 np.dot(measuredROfFx-fitROfFx,measuredROfFx-fitROfFx)))
+print("error =   [%3.2f %3.2f %3.2f %3.2f]%%" % (
+                 100*abs((measuredData[0]-fit.x[0])/measuredData[0]),
+                 100*abs((measuredData[1]-fit.x[1])/measuredData[1]),
+                 100*abs((measuredData[2]-fit.x[2])/measuredData[2]),
+                 100*abs((measuredData[3]-fit.x[3])/measuredData[3])))

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -1,6 +1,10 @@
 # This is an example of python code using VTS to provide inverse solution
-# for R(fx) to find chromophore concentrations and power law coefficients.
-# The optimization uses the Vts library MPFitLevenbergMarquardt method Solve
+# for R(fx) to find chromophore concentrations [Hb HbO2] and power law 
+# coefficients [A b] using fixed fx=[0 0.2]/mm and wavelengths=[650:50:1000]nm.  
+# Scaled Monte Carlo with Nurbs forward solver provides the simulated 
+# measured data and PointSourceSDA 
+# provides the model used during the inversion.
+# The optimization is performed by a python library scipy.
 #
 # Import the Operating System so we can access the files for the VTS library
 from pythonnet import load

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -45,15 +45,17 @@ chromophoresMeasuredData[1] = ChromophoreAbsorber(ChromophoreType.Hb, measuredDa
 opsMeasured = Tissue(chromophoresMeasuredData, scattererMeasuredData, "", n=1.4).GetOpticalProperties(wavelengths)
 # Create measurements using Nurbs-based white Monte Carlo forward solver
 measurementForwardSolver = NurbsForwardSolver()
-# len(measuredROfFx)=16 (#wavelengths)x(#fxs) organized [op1fx1, op1fx2, op2fx1, op2fx2, ...]
-measuredROfFx= measurementForwardSolver.ROfFx(opsMeasured, fxs)
+# len(measuredROfFx)=(#fxs)x(#wavelengths) flattened
+measuredROfFx=np.concatenate(
+        [np.array(measurementForwardSolver.ROfFx(opsMeasured, fxs[0]), dtype=float), 
+         np.array(measurementForwardSolver.ROfFx(opsMeasured, fxs[1]), dtype=float)])
 # Create a forward solver as a model function for inversion
 forwardSolverForInversion = PointSourceSDAForwardSolver()
 
 # Declare local forward reflectance function that computes reflectance 
 # from chromophores and scatterer values
 # valuesSought = [Hb, HbO2, A, b]
-def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
+def CalculateReflectanceVsWavelengthFromChromophoreConcAndScatterer(
     valuesSought, wavelengths, fxs, forwardSolver):
 # Create a forward solve model function to solve inverse
    forwardSolverForInversion = PointSourceSDAForwardSolver()
@@ -66,19 +68,20 @@ def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
    # Compose local tissue to obtain optical properties
    opsLocal = Tissue(chromophoresLocal, scattererLocal, "", n=1.4).GetOpticalProperties(wavelengths)
    # Compute reflectance for local absorbers
-   modelDataLocal = Array.CreateInstance(float, len(wavelengths) * len(fxs))
-   modelDataLocal = forwardSolver.ROfFx(opsLocal, fxs) 
-   modelDataForReturn= Array.CreateInstance(float, len(wavelengths) * len(fxs))
-   for i in range(0, len(wavelengths) * len(fxs)):
+   modelDataLocal=np.concatenate(
+        [np.array(forwardSolver.ROfFx(opsLocal, fxs[0]), dtype=float), 
+         np.array(forwardSolver.ROfFx(opsLocal, fxs[1]), dtype=float)])
+   modelDataForReturn=Array.CreateInstance(float, len(wavelengths)*len(fxs))
+   for i in range(0, len(fxs)*len(wavelengths)-1):
         modelDataForReturn[i] = modelDataLocal[i]
    return modelDataForReturn
 
 # func for residual
 def residual(valuesSought, wavelengths, fxs, measuredROfFx, forwardSolver):
-   predictedROfFx= CalculateReflectanceVsWavelengthFromChromophoreConcentration(
+   predictedROfFx= CalculateReflectanceVsWavelengthFromChromophoreConcAndScatterer(
       valuesSought, wavelengths, fxs, forwardSolver) 
-   difference = Array.CreateInstance(float,len(wavelengths) * len(fxs))
-   for i in range(0,len(wavelengths) * len(fxs)):
+   difference = Array.CreateInstance(float,len(wavelengths)*len(fxs))
+   for i in range(0, len(fxs)*len(wavelengths)-1):
        difference[i] = predictedROfFx[i] - measuredROfFx[i]
    return difference
 
@@ -90,7 +93,9 @@ chromophoresInitialGuess[1] = ChromophoreAbsorber(ChromophoreType.Hb, initialGue
 scattererInitialGuess = PowerLawScatterer(initialGuess[2], initialGuess[3])
 # Compose tissue for initial guess data to obtain OPs
 opsInitialGuess = Tissue(chromophoresInitialGuess, scattererInitialGuess, "", n=1.4).GetOpticalProperties(wavelengths)
-initialGuessROfFx = forwardSolverForInversion.ROfFx(opsInitialGuess, fxs) 
+initialGuessROfFx=np.concatenate(
+        [np.array(forwardSolverForInversion.ROfFx(opsInitialGuess, fxs[0]), dtype=float), 
+         np.array(forwardSolverForInversion.ROfFx(opsInitialGuess, fxs[1]), dtype=float)])
 # Run the levenberg-marquardt inversion
 from scipy.optimize import least_squares
 fit = least_squares(
@@ -106,24 +111,27 @@ chromophoresFit[1] = ChromophoreAbsorber(ChromophoreType.Hb, fit.x[1])
 scattererFit = PowerLawScatterer(fit.x[2], fit.x[3])
 # Compose tissue for fit data to obtain OPs
 opsFit= Tissue(chromophoresFit, scattererFit, "", n=1.4).GetOpticalProperties(wavelengths)
-fitROfFx = forwardSolverForInversion.ROfFx(opsFit, fxs) 
-# plot the results using Plotly data organization [op1fx1, op1fx2, op2fx1, op2,fx2,...]
+fitROfFx=np.concatenate(
+        [np.array(forwardSolverForInversion.ROfFx(opsFit, fxs[0]), dtype=float), 
+         np.array(forwardSolverForInversion.ROfFx(opsFit, fxs[1]), dtype=float)])
+# plot the results using Plotly results flattened so have to unflat
 chart = go.Figure()
 xLabel = "wavelength [nm]"
 yLabel = "R(wavelength)"
 wvs = [w for w in wavelengths]
 # plot measured data first fx first
 meas= [m for m in measuredROfFx]
-chart.add_trace(go.Scatter(x=wvs, y=meas[::2], mode='markers', name='measured data: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=meas[1:len(meas):2], mode='markers', name='measured data: fx2'))
+midpoint=len(meas) // 2
+chart.add_trace(go.Scatter(x=wvs, y=meas[:midpoint], mode='markers', name='measured data: fx1'))
+chart.add_trace(go.Scatter(x=wvs, y=meas[midpoint:], mode='markers', name='measured data: fx2'))
 # plot initial guess data
 ig = [i for i in initialGuessROfFx]
-chart.add_trace(go.Scatter(x=wvs, y=ig[::2], mode='markers', name='initial guess: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=ig[1:len(ig):2], mode='markers', name='initial guess: fx2'))
+chart.add_trace(go.Scatter(x=wvs, y=ig[:midpoint], mode='markers', name='initial guess: fx1'))
+chart.add_trace(go.Scatter(x=wvs, y=ig[midpoint:], mode='markers', name='initial guess: fx2'))
 # plot fit: need to organize by fx
 conv = [f for f in fitROfFx]
-chart.add_trace(go.Scatter(x=wvs, y=conv[::2], mode='lines', name='converged: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=conv[1:len(conv):2], mode='lines', name='converged: fx2'))
+chart.add_trace(go.Scatter(x=wvs, y=conv[:midpoint], mode='lines', name='converged: fx1'))
+chart.add_trace(go.Scatter(x=wvs, y=conv[midpoint:], mode='lines', name='converged: fx2'))
 chart.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
 
 chart.show(renderer="browser")

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -6,15 +6,12 @@
 # The optimization is performed by a python library scipy.
 #
 # Import the Operating System so we can access the files for the VTS library
-from pythonnet import load
-load('coreclr')
 import clr
 import os
 file = '../libraries/Vts.dll'
 clr.AddReference(os.path.abspath(file))
 import numpy as np
 import plotly.graph_objects as go
-import plotly.express as px
 from Vts import *
 from Vts.Common import *
 from Vts.Extensions import *
@@ -159,7 +156,6 @@ scattererFitMusp= np.zeros(len(wavelengths),dtype=float)
 for i in range(0, len(wavelengths)):
    scattererFitMusp[i]=opsFit[i].Musp
 convMusp = [f for f in scattererFitMusp]
-print('convMusp[0]=',convMusp)
 chart2.add_trace(go.Scatter(x=wvs, y=convMusp, mode='lines', name='converged'))
 chart2.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart2.show(renderer="browser")

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -114,53 +114,58 @@ rOfFxFit=np.concatenate(
         [np.array(forwardSolverForInversion.ROfFx(opsFit, fxs[0]), dtype=float), 
          np.array(forwardSolverForInversion.ROfFx(opsFit, fxs[1]), dtype=float)])
 # plot Reflectance: flattened so have to separate
-chart = go.Figure()
+chart1 = go.Figure()
 xLabel = "wavelength [nm]"
 yLabel = "R(wavelength)"
 wvs = [w for w in wavelengths]
 # plot measured data first fx first
-meas= [m for m in rOfFxMeasured]
-midpoint=len(meas) // 2
-chart.add_trace(go.Scatter(x=wvs, y=meas[:midpoint], mode='markers', name='measured data: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=meas[midpoint:], mode='markers', name='measured data: fx2'))
+measR= [m for m in rOfFxMeasured]
+midpoint=len(measR) // 2
+chart1.add_trace(go.Scatter(x=wvs, y=measR[:midpoint], mode='markers', name='measured data: fx1'))
+chart1.add_trace(go.Scatter(x=wvs, y=measR[midpoint:], mode='markers', name='measured data: fx2'))
 # plot initial guess data
-ig = [i for i in rOfFxInitialGuess]
-chart.add_trace(go.Scatter(x=wvs, y=ig[:midpoint], mode='markers', name='initial guess: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=ig[midpoint:], mode='markers', name='initial guess: fx2'))
+igR = [i for i in rOfFxInitialGuess]
+chart1.add_trace(go.Scatter(x=wvs, y=igR[:midpoint], mode='markers', name='initial guess: fx1'))
+chart1.add_trace(go.Scatter(x=wvs, y=igR[midpoint:], mode='markers', name='initial guess: fx2'))
 # plot fit: need to organize by fx
-conv = [f for f in rOfFxFit]
-chart.add_trace(go.Scatter(x=wvs, y=conv[:midpoint], mode='lines', name='converged: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=conv[midpoint:], mode='lines', name='converged: fx2'))
-chart.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
+convR = [f for f in rOfFxFit]
+chart1.add_trace(go.Scatter(x=wvs, y=convR[:midpoint], mode='lines', name='converged: fx1'))
+chart1.add_trace(go.Scatter(x=wvs, y=convR[midpoint:], mode='lines', name='converged: fx2'))
+chart1.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
+chart1.show(renderer="browser")
 # plot Mus': flattened so have to separate
-chart = go.Figure()
+chart2 = go.Figure()
 xLabel = "wavelength [nm]"
 yLabel = "us'(wavelength)"
 wvs = [w for w in wavelengths]
-# plot measured data first fx first
-meas= [m for m in scattererMeasuredData]
-midpoint=len(meas) // 2
-chart.add_trace(go.Scatter(x=wvs, y=meas[:midpoint], mode='markers', name='measured data: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=meas[midpoint:], mode='markers', name='measured data: fx2'))
+# plot measured data 
+scattererMeasuredDataMusp= np.zeros(len(wavelengths),dtype=float)
+for i in range(0, len(wavelengths)):
+   scattererMeasuredDataMusp[i]=opsMeasured[i].Musp
+measMusp = [m for m in scattererMeasuredDataMusp]
+chart2.add_trace(go.Scatter(x=wvs, y=measMusp, mode='markers', name='measured data'))
 # plot initial guess data
-ig = [i for i in [scattererInitialGuess]]
-chart.add_trace(go.Scatter(x=wvs, y=ig[:midpoint], mode='markers', name='initial guess: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=ig[midpoint:], mode='markers', name='initial guess: fx2'))
-# plot fit: need to organize by fx
-conv = [f for f in [scattererFit]]
-chart.add_trace(go.Scatter(x=wvs, y=conv[:midpoint], mode='lines', name='converged: fx1'))
-chart.add_trace(go.Scatter(x=wvs, y=conv[midpoint:], mode='lines', name='converged: fx2'))
-chart.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
-
-chart.show(renderer="browser")
+scattererInitialGuessMusp= np.zeros(len(wavelengths),dtype=float)
+for i in range(0, len(wavelengths)):
+   scattererInitialGuessMusp[i]=opsInitialGuess[i].Musp
+igMusp = [i for i in [scattererInitialGuessMusp]]
+chart2.add_trace(go.Scatter(x=wvs, y=igMusp, mode='markers', name='initial guess'))
+# plot fit
+scattererFitMusp= np.zeros(len(wavelengths),dtype=float)
+for i in range(0, len(wavelengths)):
+   scattererFitMusp[i]=opsFit[i].Musp
+convMusp = [f for f in [scattererFitMusp]]
+chart2.add_trace(go.Scatter(x=wvs, y=convMusp, mode='lines', name='converged'))
+chart2.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
+chart2.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f %5.3f]" % (
                  measuredData[0], measuredData[1], measuredData[2], measuredData[3]))
 print("IG   =    [%5.3f %5.3f %5.3f %5.3f] Chi2=%5.3e" % (
                  initialGuess[0], initialGuess[1], initialGuess[2], initialGuess[3],
-                 np.dot(measuredROfFx-initialGuessROfFx,measuredROfFx-initialGuessROfFx)))
+                 np.dot(rOfFxMeasured-rOfFxInitialGuess,rOfFxMeasured-rOfFxInitialGuess)))
 print("Conv =    [%5.3f %5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit.x[0], fit.x[1], fit.x[2], fit.x[3],
-                 np.dot(measuredROfFx-fitROfFx,measuredROfFx-fitROfFx)))
+                 np.dot(rOfFxMeasured-rOfFxFit,rOfFxMeasured-rOfFxFit)))
 print("error =   [%3.2f %3.2f %3.2f %3.2f]%%" % (
                  100*abs((measuredData[0]-fit.x[0])/measuredData[0]),
                  100*abs((measuredData[1]-fit.x[1])/measuredData[1]),

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -1,0 +1,137 @@
+# This is an example of python code using VTS to provide inverse solution
+# for R(fx) to find chromophore concentrations and power law coefficients.
+# The optimization uses the Vts library MPFitLevenbergMarquardt method Solve
+#
+# Import the Operating System so we can access the files for the VTS library
+from pythonnet import load
+load('coreclr')
+import clr
+import os
+file = '../libraries/Vts.dll'
+clr.AddReference(os.path.abspath(file))
+import numpy as np
+import plotly.graph_objects as go
+import plotly.express as px
+from Vts import *
+from Vts.Common import *
+from Vts.Extensions import *
+from Vts.Modeling.Optimizers import *
+from Vts.Modeling.ForwardSolvers import *
+from Vts.SpectralMapping import *
+from Vts.Factories import *
+from Vts.MonteCarlo import *
+from Vts.MonteCarlo.Sources import *
+from Vts.MonteCarlo.Tissues import *
+from Vts.MonteCarlo.Detectors import *
+from Vts.MonteCarlo.Factories import *
+from Vts.MonteCarlo.PhotonData import *
+from Vts.MonteCarlo.PostProcessing import *
+from System import Array, Object
+# Setup wavelengths in visible and NIR spectral regimes
+wavelengths = Array.CreateInstance(float, 8)
+for i in range(0, len(wavelengths)):
+    wavelengths[i] = 650.0 + 50 * i
+# Setup fxs
+fxs = [0.0, 0.2]
+# Define parameters to fit [Hb,HbO2,A,b]
+measuredData = [28.4, 22.4, 1.2, 1.42]
+# Construct a scatter
+scattererMeasuredData = PowerLawScatterer(measuredData[2], measuredData[3])
+# Setup the values for the measured data
+chromophoresMeasuredData = Array.CreateInstance(IChromophoreAbsorber, 2)
+chromophoresMeasuredData[0] = ChromophoreAbsorber(ChromophoreType.HbO2, measuredData[0])
+chromophoresMeasuredData[1] = ChromophoreAbsorber(ChromophoreType.Hb, measuredData[1])
+opsMeasured = Tissue(chromophoresMeasuredData, scattererMeasuredData, "", n=1.4).GetOpticalProperties(wavelengths)
+# Create measurements using Nurbs-based white Monte Carlo forward solver
+measurementForwardSolver = NurbsForwardSolver()
+measuredROfFx= measurementForwardSolver.ROfFx(opsMeasured, fxs)
+# Create a forward solver as a model function for inversion
+forwardSolverForInversion = PointSourceSDAForwardSolver()
+
+# Declare local forward reflectance function that computes reflectance 
+# from chromophores and scatterer values
+# valuesSought = [Hb, HbO2, A, b]
+def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
+    valuesSought, wavelengths, fxs, forwardSolver):
+# Create a forward solve model function to solve inverse
+   forwardSolverForInversion = PointSourceSDAForwardSolver()
+   # Create an array of chromophore absorbers based on values
+   chromophoresLocal = Array.CreateInstance(IChromophoreAbsorber, 2)
+   chromophoresLocal[0] = ChromophoreAbsorber(ChromophoreType.HbO2, valuesSought[0])
+   chromophoresLocal[1] = ChromophoreAbsorber(ChromophoreType.Hb, valuesSought[1])
+   # Create a scatterr based on values
+   scattererLocal = PowerLawScatterer(valuesSought[2], valuesSought[3])
+   # Compose local tissue to obtain optical properties
+   opsLocal = Tissue(chromophoresLocal, scattererLocal, "", n=1.4).GetOpticalProperties(wavelengths)
+   print('opsLocal[0]=',opsLocal[0])
+   # Compute reflectance for local absorbers
+   modelDataLocal = Array.CreateInstance(float, len(wavelengths) * len(fxs))
+   modelDataLocal = forwardSolver.ROfFx(opsLocal, fxs) 
+   print('modelDataLocal dims=',len(modelDataLocal))
+   modelDataForReturn= Array.CreateInstance(float, len(wavelengths) * len(fxs))
+   for i in range(0, len(wavelengths) * len(fxs)):
+        modelDataForReturn[i] = modelDataLocal[i]
+   return modelDataForReturn
+
+# func for residual
+def residual(valuesSought, wavelengths, fxs, measuredROfFx, forwardSolver):
+   predictedROfFx= CalculateReflectanceVsWavelengthFromChromophoreConcentration(
+      valuesSought, wavelengths, fxs, forwardSolver) 
+   difference = Array.CreateInstance(float,len(wavelengths) * len(fxs))
+   for i in range(0,len(wavelengths) * len(fxs)):
+       difference[i] = predictedROfFx[i] - measuredROfFx[i]
+   return difference
+
+# Run the inversion: set up initial guess 
+initialGuess = [18.0, 30.0, 0.8, 1.60]
+chromophoresInitialGuess = Array.CreateInstance(IChromophoreAbsorber, 2)
+chromophoresInitialGuess[0] = ChromophoreAbsorber(ChromophoreType.HbO2, initialGuess[0])
+chromophoresInitialGuess[1] = ChromophoreAbsorber(ChromophoreType.Hb, initialGuess[1])
+scattererInitialGuess = PowerLawScatterer(initialGuess[2], initialGuess[3])
+# Compose tissue for initial guess data to obtain OPs
+opsInitialGuess = Tissue(chromophoresInitialGuess, scattererInitialGuess, "", n=1.4).GetOpticalProperties(wavelengths)
+initialGuessROfFx = forwardSolverForInversion.ROfFx(opsInitialGuess, fxs) 
+# Run the levenberg-marquardt inversion
+from scipy.optimize import least_squares
+fit = least_squares(
+   residual,
+   initialGuess, 
+   ftol=1e-9, xtol=1e-9, max_nfev=10000, # max_nfev needs to be integer
+   args=(wavelengths, fxs, measuredROfFx, forwardSolverForInversion), 
+   method='lm')
+# Calculate final reflectance from model at fit values
+chromophoresFit = Array.CreateInstance(IChromophoreAbsorber, 2)
+chromophoresFit[0] = ChromophoreAbsorber(ChromophoreType.HbO2, fit.x[0])
+chromophoresFit[1] = ChromophoreAbsorber(ChromophoreType.Hb, fit.x[1])
+scattererFit = PowerLawScatterer(fit.x[2], fit.x[3])
+# Compose tissue for fit data to obtain OPs
+opsFit= Tissue(chromophoresFit, scattererFit, "", n=1.4).GetOpticalProperties(wavelengths)
+fitROfFx = forwardSolverForInversion.ROfFx(opsFit, fxs) 
+# plot the results using Plotly
+xLabel = "wavelength [nm]"
+yLabel = "R(wavelength)"
+wvs = [w for w in wavelengths]
+# plot measured data
+meas = [m for m in measuredROfFx]
+chart = go.Figure()
+chart.add_trace(go.Scatter(x=wvs, y=meas, mode='markers', name='measured data'))
+# plot initial guess data
+ig = [i for i in initialGuessROfFx]
+chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
+# plot fit
+conv = [f for f in fitROfFx]
+chart.add_trace(go.Scatter(x=wvs, y=conv, mode='lines', name='converged'))
+chart.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.show(renderer="browser")
+# output results
+print("Meas =    [%5.3f %5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2], measuredData[3]))
+print("IG   =    [%5.3f %5.3f %5.3f %5.3f] Chi2=%5.3e" % (
+                 initialGuess[0], initialGuess[1], initialGuess[2], initialGuess[3],
+                 np.dot(measuredROfFx,initialGuessROfFx)))
+print("Conv =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit.x[0], fit.x[1], fit.x[2], fit.x[3],
+                 np.dot(measuredROfFx,fitROfFx)))
+print("error =   [%5.3f %5.3f %5.3f %5.3f]" % (
+                 abs((measuredData[0]-fit.x[0])/measuredData[0]),
+                 abs((measuredData[1]-fit.x[1])/measuredData[1]),
+                 abs((measuredData[2]-fit.x[2])/measuredData[2]),
+                 abs((measuredData[3]-fit.x[3])/measuredData[3])))

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -2,8 +2,7 @@
 # for R(fx) to find chromophore concentrations [Hb HbO2] and power law 
 # coefficients [A b] using fixed fx=[0 0.2]/mm and wavelengths=[650:50:1000]nm.  
 # Scaled Monte Carlo with Nurbs forward solver provides the simulated 
-# measured data and PointSourceSDA 
-# provides the model used during the inversion.
+# measured data and PointSourceSDA provides the model used during the inversion.
 # The optimization is performed by a python library scipy.
 #
 # Import the Operating System so we can access the files for the VTS library

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -6,6 +6,8 @@
 # The optimization is performed by a python library scipy.
 #
 # Import the Operating System so we can access the files for the VTS library
+from pythonnet import load
+load('coreclr')
 import clr
 import os
 file = '../libraries/Vts.dll'

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -51,6 +51,7 @@ rOfFxMeasured=np.concatenate(
          np.array(measurementForwardSolver.ROfFx(opsMeasured, fxs[1]), dtype=float)])
 # Create a forward solver as a model function for inversion
 forwardSolverForInversion = PointSourceSDAForwardSolver()
+#forwardSolverForInversion = NurbsForwardSolver() # results improved but inverse crime!
 
 # Declare local forward reflectance function that computes reflectance 
 # from chromophores and scatterer values
@@ -85,7 +86,7 @@ def residual(valuesSought, wavelengths, fxs, measuredROfFx, forwardSolver):
    return difference
 
 # Run the inversion: set up initial guess 
-initialGuess = [18.0, 30.0, 0.8, 1.60]
+initialGuess = [18.0, 30.0, 0.8, 1.6]
 chromophoresInitialGuess = Array.CreateInstance(IChromophoreAbsorber, 2)
 chromophoresInitialGuess[0] = ChromophoreAbsorber(ChromophoreType.HbO2, initialGuess[0])
 chromophoresInitialGuess[1] = ChromophoreAbsorber(ChromophoreType.Hb, initialGuess[1])

--- a/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-fx-multi-op-prop-inversion.py
@@ -148,13 +148,14 @@ chart2.add_trace(go.Scatter(x=wvs, y=measMusp, mode='markers', name='measured da
 scattererInitialGuessMusp= np.zeros(len(wavelengths),dtype=float)
 for i in range(0, len(wavelengths)):
    scattererInitialGuessMusp[i]=opsInitialGuess[i].Musp
-igMusp = [i for i in [scattererInitialGuessMusp]]
+igMusp = [i for i in scattererInitialGuessMusp]
 chart2.add_trace(go.Scatter(x=wvs, y=igMusp, mode='markers', name='initial guess'))
 # plot fit
 scattererFitMusp= np.zeros(len(wavelengths),dtype=float)
 for i in range(0, len(wavelengths)):
    scattererFitMusp[i]=opsFit[i].Musp
-convMusp = [f for f in [scattererFitMusp]]
+convMusp = [f for f in scattererFitMusp]
+print('convMusp[0]=',convMusp)
 chart2.add_trace(go.Scatter(x=wvs, y=convMusp, mode='lines', name='converged'))
 chart2.update_layout( title="ROfFx (inverse solution for chromophore concentrations, multiple wavelengths, multiple fx)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart2.show(renderer="browser")

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -60,7 +60,8 @@ def CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration(
     chromophoresLocal[2] = ChromophoreAbsorber(ChromophoreType.H2O, chromophoreConcentration[2])
     # Compose local tissue to obtain optical properties
     opsLocal = Tissue(chromophoresLocal, params[2], "", n=1.4).GetOpticalProperties(params[0])
-    print('opsLocal[0]=',opsLocal[0])
+    print("iter:[HbO2,Hb,H2O]=[%3.2f %3.2f %3.2f]" % (
+       chromophoreConcentration[0],chromophoreConcentration[1],chromophoreConcentration[2]))
     # Compute reflectance for local absorbers
     modelDataLocal = forwardSolverForInversion.ROfRho(opsLocal, params[1]) 
     modelDataLocalCSharp = Array.CreateInstance(float, len(wavelengths))
@@ -120,11 +121,15 @@ chart.update_layout( title="ROfRho (inverse solution for chromophore concentrati
 chart.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))
-print("IG   =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (initialGuess[0], initialGuess[1], initialGuess[2],
-                np.dot(measuredROfRho,initialGuessROfRho)))
+print("IG   =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (
+                initialGuess[0], initialGuess[1], initialGuess[2],
+                np.dot(np.subtract(measuredROfRho,initialGuessROfRho),
+                       np.subtract(measuredROfRho,initialGuessROfRho))))
 print("Conv =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit[0], fit[1], fit[2],
-                np.dot(measuredROfRho,fitROfRho)))
-print("error =   [%5.3f %5.3f %5.3f]" % (abs((measuredData[0]-fit[0])/measuredData[0]),
-                abs((measuredData[1]-fit[1])/measuredData[1]),
-                abs((measuredData[2]-fit[2])/measuredData[2])))
+                np.dot(np.subtract(measuredROfRho,fitROfRho),
+                       np.subtract(measuredROfRho,fitROfRho))))
+print("error =   [%5.3f %5.3f %5.3f]%%" % (
+                100*abs((measuredData[0]-fit[0])/measuredData[0]),
+                100*abs((measuredData[1]-fit[1])/measuredData[1]),
+                100*abs((measuredData[2]-fit[2])/measuredData[2])))
 

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -45,7 +45,7 @@ chromophoresMeasuredData[2] = ChromophoreAbsorber(ChromophoreType.H2O, measuredD
 opsMeasured = Tissue(chromophoresMeasuredData, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
 # Create measurements using Nurbs-based white Monte Carlo forward solver
 measurementForwardSolver = NurbsForwardSolver()
-measuredROfRho = measurementForwardSolver.ROfRho(opsMeasured, rho)
+rOfRhoMeasured = measurementForwardSolver.ROfRho(opsMeasured, rho)
 # Create a forward solver as a model function for inversion
 forwardSolverForInversion = PointSourceSDAForwardSolver()
 
@@ -77,20 +77,20 @@ chromophoresInitialGuess[1] = ChromophoreAbsorber(ChromophoreType.Hb, initialGue
 chromophoresInitialGuess[2] = ChromophoreAbsorber(ChromophoreType.H2O, initialGuess[2])
 # Compose tissue for initial guess data to obtain OPs
 opsInitialGuess = Tissue(chromophoresInitialGuess, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
-initialGuessROfRho = forwardSolverForInversion.ROfRho(opsInitialGuess, rho)
+rOfRhoInitialGuess = forwardSolverForInversion.ROfRho(opsInitialGuess, rho)
 # Run the levenberg-marquardt inversion
 optimizer = MPFitLevenbergMarquardtOptimizer()
 initialGuessCopy = Array.CreateInstance(float, 3)
 initialGuessCopy = initialGuess
 parametersToFit = Array.CreateInstance(bool, 3)
 parametersToFit = [True, True, True]
-measuredDataWeight = Array.CreateInstance(float, len(measuredROfRho))
+measuredDataWeight = Array.CreateInstance(float, len(rOfRhoMeasured))
 measuredDataWeight = [1] * len(measuredDataWeight)
 params = Array.CreateInstance(Object, 3)
 params = [wavelengths, rho, scatterer]
 
 # try calling our LM
-fit = optimizer.Solve(initialGuessCopy, parametersToFit, measuredROfRho, measuredDataWeight, 
+fit = optimizer.Solve(initialGuessCopy, parametersToFit, rOfRhoMeasured, measuredDataWeight, 
    forward_func, params)
 # Calculate final reflectance from model at fit values
 chromophoresFit = Array.CreateInstance(IChromophoreAbsorber, 3)
@@ -98,20 +98,20 @@ chromophoresFit[0] = ChromophoreAbsorber(ChromophoreType.HbO2, fit[0])
 chromophoresFit[1] = ChromophoreAbsorber(ChromophoreType.Hb, fit[1])
 chromophoresFit[2] = ChromophoreAbsorber(ChromophoreType.H2O, fit[2])
 opsFit = Tissue(chromophoresFit, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
-fitROfRho= forwardSolverForInversion.ROfRho(opsFit, rho)
+rOfRhoFit= forwardSolverForInversion.ROfRho(opsFit, rho)
 # plot the results using Plotly
 xLabel = "wavelengths [nm]"
 yLabel = "R(wavelength) [mm-2]"
 wvs = [w for w in wavelengths]
 # plot measured data
-meas = [m for m in measuredROfRho]
+meas = [m for m in rOfRhoMeasured]
 chart = go.Figure()
 chart.add_trace(go.Scatter(x=wvs, y=meas, mode='markers', name='measured data'))
 # plot initial guess data
-ig = [i for i in initialGuessROfRho]
+ig = [i for i in rOfRhoInitialGuess]
 chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
 # plot fit
-conv = [f for f in fitROfRho]
+conv = [f for f in rOfRhoFit]
 chart.add_trace(go.Scatter(x=wvs, y=conv, mode='lines', name='converged'))
 chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelengths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart.show(renderer="browser")
@@ -119,11 +119,11 @@ chart.show(renderer="browser")
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))
 print("IG   =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (
                 initialGuess[0], initialGuess[1], initialGuess[2],
-                np.dot(np.subtract(measuredROfRho,initialGuessROfRho),
-                       np.subtract(measuredROfRho,initialGuessROfRho))))
+                np.dot(np.subtract(rOfRhoMeasured,rOfRhoInitialGuess),
+                       np.subtract(rOfRhoMeasured,rOfRhoInitialGuess))))
 print("Conv =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit[0], fit[1], fit[2],
-                np.dot(np.subtract(measuredROfRho,fitROfRho),
-                       np.subtract(measuredROfRho,fitROfRho))))
+                np.dot(np.subtract(rOfRhoMeasured,rOfRhoFit),
+                       np.subtract(rOfRhoMeasured,rOfRhoFit))))
 print("error =   [%5.3f %5.3f %5.3f]%%" % (
                 100*abs((measuredData[0]-fit[0])/measuredData[0]),
                 100*abs((measuredData[1]-fit[1])/measuredData[1]),

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -89,8 +89,8 @@ initialGuessCopy = Array.CreateInstance(float, 3)
 initialGuessCopy = initialGuess
 parametersToFit = Array.CreateInstance(bool, 3)
 parametersToFit = [True, True, True]
-measuredDataWeight = Array.CreateInstance(float, 3)
-measuredDataWeight = [1, 1, 1]
+measuredDataWeight = Array.CreateInstance(float, len(measuredROfRho))
+measuredDataWeight = [1] * len(measuredDataWeight)
 params = Array.CreateInstance(Object, 3)
 params = [wavelengths, rho, scatterer]
 

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -9,6 +9,8 @@
 # method Solve.
 #
 # Import the Operating System so we can access the files for the VTS library
+from pythonnet import load
+load('coreclr')
 import clr
 import os
 file = '../libraries/Vts.dll'

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -1,0 +1,132 @@
+# This is an example of python code using VTS to provide inverse solution
+# for R(rho) to find chromophore concentrations and power law coefficients
+#
+# Import the Operating System so we can access the files for the VTS library
+from pythonnet import load
+load('coreclr')
+import clr
+import os
+file = '../libraries/Vts.dll'
+print('Does this filepath exist?', os.path.isfile(file))
+clr.AddReference(os.path.abspath(file))
+import numpy as np
+import plotly.graph_objects as go
+import plotly.express as px
+from Vts import *
+from Vts.Common import *
+from Vts.Extensions import *
+from Vts.Modeling.Optimizers import *
+from Vts.Modeling.ForwardSolvers import *
+from Vts.SpectralMapping import *
+from Vts.Factories import *
+from Vts.MonteCarlo import *
+from Vts.MonteCarlo.Sources import *
+from Vts.MonteCarlo.Tissues import *
+from Vts.MonteCarlo.Detectors import *
+from Vts.MonteCarlo.Factories import *
+from Vts.MonteCarlo.PhotonData import *
+from Vts.MonteCarlo.PostProcessing import *
+from System import Array, Object
+# Construct a scatterer
+scatterer = PowerLawScatterer(1.2, 1.42)
+# Setup wavelengths in visible and NIR spectral regimes
+wavelengths = Array.CreateInstance(float, 600)
+for i in range(0, len(wavelengths)-1):
+    wavelengths[i] = 400.0 + i 
+print('wavelengths[0]=',wavelengths[0])
+# Define rho
+rho = 1.0
+# Setup the values for the measured data
+chromophoresMeasuredData = Array.CreateInstance(IChromophoreAbsorber, 3)
+chromophoresMeasuredData[0] = ChromophoreAbsorber(ChromophoreType.HbO2, 70)
+chromophoresMeasuredData[1] = ChromophoreAbsorber(ChromophoreType.Hb, 30)
+chromophoresMeasuredData[2] = ChromophoreAbsorber(ChromophoreType.H2O, 0.8)
+opsMeasured = Tissue(chromophoresMeasuredData, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+print('opsMeasured[0]=',opsMeasured[0])
+# Create measurements using Nurbs-based white Monte Carlo forward solver
+measurementForwardSolver = NurbsForwardSolver()
+measuredData = measurementForwardSolver.ROfRho(opsMeasured, rho)
+print('measuredData[0]=',measuredData[0])
+# Create a forward solver as a model function for inversion
+forwardSolverForInversion = NurbsForwardSolver()
+
+# Declare local forward reflectance function that computes reflectance from chromophores
+# params=[wavelengths, rho, scatterer]
+def CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration(
+        chromophoreConcentration, params):   
+   # Create a forward solve model function to solve inverse
+   def forwardFunc(chromophoreConcentration, params):
+      # following sub for func = GetForwardReflectanceFuncForOptimization(forwardSolverForInversion,
+      # solutionDomainType)
+      # Create an array of chromophore absorbers based on values
+      chromophoresLocal = Array.CreateInstance(IChromophoreAbsorber, 3)
+      chromophoresLocal[0] = ChromophoreAbsorber(ChromophoreType.HbO2, chromophoreConcentration[0])
+      chromophoresLocal[1] = ChromophoreAbsorber(ChromophoreType.Hb, chromophoreConcentration[1])
+      chromophoresLocal[2] = ChromophoreAbsorber(ChromophoreType.H2O, chromophoreConcentration[2])
+      # Compose local tissue to obtain optical properties
+      opsLocal = Tissue(chromophoresLocal, params[2], "", n=1.4).GetOpticalProperties(params[0])
+      print('opsLocal[0]=',opsLocal[0])
+      # Compute reflectance for local absorbers
+      modelDataLocal = forwardSolverForInversion.ROfRho(opsLocal, params[1]) 
+      modelDataLocalCSharp = Array.CreateInstance(float, len(wavelengths))
+      # convert to C# format
+      for i in range(0, len(params[0])-1):
+          modelDataLocalCSharp[i] = modelDataLocal[i]
+      return modelDataLocalCSharp
+      return forwardFunc(chromophoreConcentration, params)
+
+# Run the inversion: set up initial guess
+initialGuess = [70.0, 30.0, 0.8]
+chromophoresInitialGuess = Array.CreateInstance(IChromophoreAbsorber, 3)
+chromophoresInitialGuess[0] = ChromophoreAbsorber(ChromophoreType.HbO2, initialGuess[0])
+chromophoresInitialGuess[1] = ChromophoreAbsorber(ChromophoreType.Hb, initialGuess[1])
+chromophoresInitialGuess[2] = ChromophoreAbsorber(ChromophoreType.H2O, initialGuess[2])
+# Compose tissue for initial guess data to obtain OPs
+opsInitialGuess = Tissue(chromophoresInitialGuess, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+# Run the levenberg-marquardt inversion
+optimizer = MPFitLevenbergMarquardtOptimizer()
+initialGuess = Array.CreateInstance(float, 3)
+initialGuess[0] = 70
+initialGuess[1] = 30
+initialGuess[2] = 0.8 
+parametersToFit = Array.CreateInstance(bool, 3)
+parametersToFit[0] = True
+parametersToFit[1] = True
+parametersToFit[2] = True 
+measuredDataWeight = Array.CreateInstance(float, 3)
+measuredDataWeight[0] = 1
+measuredDataWeight[1] = 1
+measuredDataWeight[2] = 1
+params = [ wavelengths, rho, scatterer ]
+initialGuessCopy = initialGuess
+
+# try calling our LM
+fit = optimizer.Solve(initialGuessCopy, parametersToFit, measuredData, measuredDataWeight, 
+   CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration, params)
+print('fit=',fit)
+# Calculate final reflectance from model at fit values
+chromophoresFit = Array.CreateInstance(IChromophoreAbsorber, 3)
+chromophoresFit[0] = ChromophoreAbsorber(ChromophoreType.HbO2, fit.x[0])
+chromophoresFit[1] = ChromophoreAbsorber(ChromophoreType.Hb, fit.x[1])
+chromophoresFit[2] = ChromophoreAbsorber(ChromophoreType.H2O, fit.x[2])
+opsFit = Tissue(chromophoresFit, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+fitReflectanceSpectrum = forwardSolverForInversion.ROfRho(opsFit, rho)
+# plot the results using Plotly
+xLabel = "wavelengths [nm]"
+yLabel = "R(wavelength) [mm-2]"
+wvs = [w for w in wavelengths]
+print('wvs[0]=',wvs[0])
+# plot measured data
+meas = [m for m in measuredData]
+chart = go.Figure()
+chart.add_trace(go.Scatter(x=wvs, y=meas, mode='markers', name='measured data'))
+# plot initial guess data
+initialGuessR = forwardSolverForInversion.ROfRho(opsInitialGuess, rho)
+ig = [i for i in initialGuessR]
+chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
+# plot fit
+fit = [f for f in fitReflectanceSpectrum]
+chart.add_trace(go.Scatter(x=wvs, y=fit, mode='markers', name='fit'))
+chart.update_layout( title="R(wavelength) [mm-2]", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.show(renderer="browser")
+

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -121,10 +121,16 @@ ig = [i for i in initialGuessROfRho]
 chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
 # plot fit
 conv = [f for f in fitROfRho]
-chart.add_trace(go.Scatter(x=wvs, y=conv, mode='markers', name='converged'))
-chart.update_layout( title="R(wavelength) [mm-2]", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.add_trace(go.Scatter(x=wvs, y=conv, mode='lines', name='converged'))
+chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelenths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))
-print("IG   =    [%5.3f %5.3f %5.3f]" % (initialGuess[0], initialGuess[1], initialGuess[2]))
-print("Conv =    [%5.3f %5.3f %5.3f]" % (fit.x[0], fit.x[1], fit.x[2]))
+print("IG   =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (initialGuess[0], initialGuess[1], initialGuess[2],
+                np.dot(measuredROfRho,initialGuessROfRho)))
+print("Conv =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit.x[0], fit.x[1], fit.x[2],
+                np.dot(measuredROfRho,fitROfRho)))
+print("error =   [%5.3f %5.3f %5.3f]" % (abs((measuredData[0]-fit.x[0])/measuredData[0]),
+                abs((measuredData[1]-fit.x[1])/measuredData[1]),
+                abs((measuredData[2]-fit.x[2])/measuredData[2])))
+

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -104,7 +104,7 @@ chromophoresFit[2] = ChromophoreAbsorber(ChromophoreType.H2O, fit[2])
 opsFit = Tissue(chromophoresFit, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
 rOfRhoFit= forwardSolverForInversion.ROfRho(opsFit, rho)
 # plot the results using Plotly
-xLabel = "wavelengths [nm]"
+xLabel = "wavelength [nm]"
 yLabel = "R(wavelength) [mm-2]"
 wvs = [w for w in wavelengths]
 # plot measured data

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -1,5 +1,10 @@
 # This is an example of python code using VTS to provide inverse solution
-# for R(rho) to find chromophore concentrations and power law coefficients.
+# for R(rho) to find chromophore concentrations of [Hb HbO2 H2O], with
+# fixed single rho=1mm, 13 wavelengths [400:50:1000]nm and scatterer
+# Power Law coefficients A=1.2, b=1.42.
+# Scaled Monte Carlo with Nurbs forward solver provides the simulated
+# measured data and PointSourceSDA provides the model used during the
+# inversion.
 # The optimization is performed by the Vts library MPFitLevenbergMarquardt
 # method Solve.
 #

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -9,15 +9,12 @@
 # method Solve.
 #
 # Import the Operating System so we can access the files for the VTS library
-from pythonnet import load
-load('coreclr')
 import clr
 import os
 file = '../libraries/Vts.dll'
 clr.AddReference(os.path.abspath(file))
 import numpy as np
 import plotly.graph_objects as go
-import plotly.express as px
 from Vts import *
 from Vts.Common import *
 from Vts.Extensions import *

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -64,11 +64,7 @@ def CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration(
        chromophoreConcentration[0],chromophoreConcentration[1],chromophoreConcentration[2]))
     # Compute reflectance for local absorbers
     modelDataLocal = forwardSolverForInversion.ROfRho(opsLocal, params[1]) 
-    modelDataLocalCSharp = Array.CreateInstance(float, len(wavelengths))
-    # convert to C# format
-    for i in range(0, len(params[0])-1):
-      modelDataLocalCSharp[i] = modelDataLocal[i]
-    return modelDataLocalCSharp
+    return modelDataLocal
 
 # Convert the Python function to a .NET Func delegate
 forward_func = Func[Array[float], Array[Object], Array[float]](CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration)

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -1,5 +1,7 @@
 # This is an example of python code using VTS to provide inverse solution
-# for R(rho) to find chromophore concentrations and power law coefficients
+# for R(rho) to find chromophore concentrations and power law coefficients.
+# The optimization is performed by the Vts library MPFitLevenbergMarquardt
+# method Solve.
 #
 # Import the Operating System so we can access the files for the VTS library
 from pythonnet import load
@@ -114,7 +116,7 @@ chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
 # plot fit
 conv = [f for f in fitROfRho]
 chart.add_trace(go.Scatter(x=wvs, y=conv, mode='lines', name='converged'))
-chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelenths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelengths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion-using-csharp-solve.py
@@ -51,9 +51,6 @@ forwardSolverForInversion = PointSourceSDAForwardSolver()
 # params=[wavelengths, rho, scatterer]
 def CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration(
         chromophoreConcentration, params):   
-    print('params[0][0]=',params[0][0])
-    print('params[1]=',params[1])
-    print('params[2]=',params[2])
     # Create an array of chromophore absorbers based on values
     chromophoresLocal = Array.CreateInstance(IChromophoreAbsorber, 3)
     chromophoresLocal[0] = ChromophoreAbsorber(ChromophoreType.HbO2, chromophoreConcentration[0])
@@ -68,7 +65,6 @@ def CalculateReflectanceFuncVsWavelengthFromChromophoreConcentration(
     # convert to C# format
     for i in range(0, len(params[0])-1):
       modelDataLocalCSharp[i] = modelDataLocal[i]
-    print('modelDataLocalCSharp[0]=',modelDataLocalCSharp[0])
     return modelDataLocalCSharp
 
 # Convert the Python function to a .NET Func delegate

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -1,6 +1,12 @@
 # This is an example of python code using VTS to provide inverse solution
-# for R(rho) to find chromophore concentrations and power law coefficients.
-# The optimization is performed by a python library scipy.
+# for R(rho) to find chromophore concentrations of [Hb HbO2 H2O], with
+# fixed single rho=1mm, 13 wavelengths [400:50:1000]nm and scatterer 
+# Power Law coefficients A=1.2, b=1.42.
+# Scaled Monte Carlo with Nurbs forward solver provides the simulated 
+# measured data and PointSourceSDA provides the model used during the 
+# inversion.
+# The optimization is performed by a python library scipy. 
+
 #
 # Import the Operating System so we can access the files for the VTS library
 from pythonnet import load

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -65,10 +65,7 @@ def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
    # Compute reflectance for local absorbers
    modelDataLocal = Array.CreateInstance(float, len(wavelengths))
    modelDataLocal = forwardSolver.ROfRho(opsLocal, rho) 
-   modelDataForReturn= Array.CreateInstance(float, len(wavelengths))
-   for i in range(0, len(wavelengths)):
-        modelDataForReturn[i] = modelDataLocal[i]
-   return modelDataForReturn
+   return modelDataLocal
 
 # func for residual
 def residual(chromophoreConcentration, wavelengths, rho, scatterer, measuredROfRho, forwardSolver):

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -1,5 +1,6 @@
 # This is an example of python code using VTS to provide inverse solution
-# for R(rho) to find chromophore concentrations and power law coefficients
+# for R(rho) to find chromophore concentrations and power law coefficients.
+# The optimization is performed by a python library scipy.
 #
 # Import the Operating System so we can access the files for the VTS library
 from pythonnet import load
@@ -115,7 +116,7 @@ chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
 # plot fit
 conv = [f for f in fitROfRho]
 chart.add_trace(go.Scatter(x=wvs, y=conv, mode='lines', name='converged'))
-chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelenths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelengths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -103,8 +103,8 @@ chromophoresFit[2] = ChromophoreAbsorber(ChromophoreType.H2O, fit.x[2])
 opsFit = Tissue(chromophoresFit, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
 fitROfRho= forwardSolverForInversion.ROfRho(opsFit, rho)
 # plot the results using Plotly
-xLabel = "wavelengths [nm]"
-yLabel = "R(wavelength) [mm-2]"
+xLabel = "wavelength [nm]"
+yLabel = "R(wavelength)"
 wvs = [w for w in wavelengths]
 # plot measured data
 meas = [m for m in measuredROfRho]
@@ -115,10 +115,15 @@ ig = [i for i in initialGuessROfRho]
 chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
 # plot fit
 conv = [f for f in fitROfRho]
-chart.add_trace(go.Scatter(x=wvs, y=conv, mode='markers', name='converged'))
-chart.update_layout( title="R(wavelength) [mm-2]", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.add_trace(go.Scatter(x=wvs, y=conv, mode='lines', name='converged'))
+chart.update_layout( title="ROfRho (inverse solution for chromophore concentrations, multiple wavelenths, single rho)", xaxis_title=xLabel, yaxis_title=yLabel)
 chart.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))
-print("IG   =    [%5.3f %5.3f %5.3f]" % (initialGuess[0], initialGuess[1], initialGuess[2]))
-print("Conv =    [%5.3f %5.3f %5.3f]" % (fit.x[0], fit.x[1], fit.x[2]))
+print("IG   =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (initialGuess[0], initialGuess[1], initialGuess[2],
+                np.dot(measuredROfRho,initialGuessROfRho)))
+print("Conv =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit.x[0], fit.x[1], fit.x[2],
+                np.dot(measuredROfRho,fitROfRho)))
+print("error =   [%5.3f %5.3f %5.3f]" % (abs((measuredData[0]-fit.x[0])/measuredData[0]),
+                abs((measuredData[1]-fit.x[1])/measuredData[1]),
+                abs((measuredData[2]-fit.x[2])/measuredData[2])))

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -60,7 +60,8 @@ def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
    chromophoresLocal[2] = ChromophoreAbsorber(ChromophoreType.H2O, chromophoreConcentration[2])
    # Compose local tissue to obtain optical properties
    opsLocal = Tissue(chromophoresLocal, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
-   print('opsLocal[0]=',opsLocal[0])
+   print("iter:[HbO2,Hb,H2O]=[%3.2f %3.2f %3.2f]" % (
+       chromophoreConcentration[0],chromophoreConcentration[1],chromophoreConcentration[2]))
    # Compute reflectance for local absorbers
    modelDataLocal = Array.CreateInstance(float, len(wavelengths))
    modelDataLocal = forwardSolver.ROfRho(opsLocal, rho) 
@@ -121,9 +122,12 @@ chart.show(renderer="browser")
 # output results
 print("Meas =    [%5.3f %5.3f %5.3f]" % (measuredData[0], measuredData[1], measuredData[2]))
 print("IG   =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (initialGuess[0], initialGuess[1], initialGuess[2],
-                np.dot(measuredROfRho,initialGuessROfRho)))
+                np.dot(np.subtract(measuredROfRho,initialGuessROfRho),
+                       np.subtract(measuredROfRho,initialGuessROfRho))))
 print("Conv =    [%5.3f %5.3f %5.3f] Chi2=%5.3e" % (fit.x[0], fit.x[1], fit.x[2],
-                np.dot(measuredROfRho,fitROfRho)))
-print("error =   [%5.3f %5.3f %5.3f]" % (abs((measuredData[0]-fit.x[0])/measuredData[0]),
-                abs((measuredData[1]-fit.x[1])/measuredData[1]),
-                abs((measuredData[2]-fit.x[2])/measuredData[2])))
+                np.dot(np.subtract(measuredROfRho,fitROfRho),
+                       np.subtract(measuredROfRho,fitROfRho))))
+print("error =   [%5.3f %5.3f %5.3f]%%" % (
+                100*abs((measuredData[0]-fit.x[0])/measuredData[0]),
+                100*abs((measuredData[1]-fit.x[1])/measuredData[1]),
+                100*abs((measuredData[2]-fit.x[2])/measuredData[2])))

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -9,6 +9,8 @@
 
 #
 # Import the Operating System so we can access the files for the VTS library
+from pythonnet import load
+load('coreclr')
 import clr
 import os
 file = '../libraries/Vts.dll'
@@ -105,7 +107,7 @@ opsFit = Tissue(chromophoresFit, scatterer, "", n=1.4).GetOpticalProperties(wave
 rOfRhoFit= forwardSolverForInversion.ROfRho(opsFit, rho)
 # plot the results using Plotly
 xLabel = "wavelength [nm]"
-yLabel = "R(wavelength)"
+yLabel = "R(wavelength) [mm-2]"
 wvs = [w for w in wavelengths]
 # plot measured data
 meas = [m for m in rOfRhoMeasured]

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -9,15 +9,12 @@
 
 #
 # Import the Operating System so we can access the files for the VTS library
-from pythonnet import load
-load('coreclr')
 import clr
 import os
 file = '../libraries/Vts.dll'
 clr.AddReference(os.path.abspath(file))
 import numpy as np
 import plotly.graph_objects as go
-import plotly.express as px
 from Vts import *
 from Vts.Common import *
 from Vts.Extensions import *

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -66,7 +66,6 @@ def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
    modelDataForReturn= Array.CreateInstance(float, len(wavelengths))
    for i in range(0, len(wavelengths)):
         modelDataForReturn[i] = modelDataLocal[i]
-   print('modelDataForReturn[0]=',modelDataForReturn[0])
    return modelDataForReturn
 
 # func for residual

--- a/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
+++ b/inverse-solutions/r-of-rho-multi-op-prop-inversion.py
@@ -1,0 +1,132 @@
+# This is an example of python code using VTS to provide inverse solution
+# for R(rho) to find chromophore concentrations and power law coefficients
+#
+# Import the Operating System so we can access the files for the VTS library
+from pythonnet import load
+load('coreclr')
+import clr
+import os
+file = '../libraries/Vts.dll'
+print('Does this filepath exist?', os.path.isfile(file))
+clr.AddReference(os.path.abspath(file))
+import numpy as np
+import plotly.graph_objects as go
+import plotly.express as px
+from Vts import *
+from Vts.Common import *
+from Vts.Extensions import *
+from Vts.Modeling.Optimizers import *
+from Vts.Modeling.ForwardSolvers import *
+from Vts.SpectralMapping import *
+from Vts.Factories import *
+from Vts.MonteCarlo import *
+from Vts.MonteCarlo.Sources import *
+from Vts.MonteCarlo.Tissues import *
+from Vts.MonteCarlo.Detectors import *
+from Vts.MonteCarlo.Factories import *
+from Vts.MonteCarlo.PhotonData import *
+from Vts.MonteCarlo.PostProcessing import *
+from System import Array, Object
+# Construct a scatterer
+scatterer = PowerLawScatterer(1.2, 1.42)
+# Setup wavelengths in visible and NIR spectral regimes
+wavelengths = Array.CreateInstance(float, 600)
+for i in range(0, len(wavelengths)-1):
+    wavelengths[i] = 400.0 + i 
+print('wavelengths[0]=',wavelengths[0])
+# Define rho
+rho = 1.0
+# Setup the values for the measured data
+chromophoresMeasuredData = Array.CreateInstance(IChromophoreAbsorber, 3)
+chromophoresMeasuredData[0] = ChromophoreAbsorber(ChromophoreType.HbO2, 70)
+chromophoresMeasuredData[1] = ChromophoreAbsorber(ChromophoreType.Hb, 30)
+chromophoresMeasuredData[2] = ChromophoreAbsorber(ChromophoreType.H2O, 0.8)
+opsMeasured = Tissue(chromophoresMeasuredData, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+print('opsMeasured[0]=',opsMeasured[0])
+# Create measurements using white Monte Carlo forward solver
+measurementForwardSolver = NurbsForwardSolver()
+measuredData = measurementForwardSolver.ROfRho(opsMeasured, rho)
+print('measuredData[0]=',measuredData[0])
+# Create a forward solver as a model function for inversion
+forwardSolverForInversion = NurbsForwardSolver()
+
+# Declare local forward reflectance function that computes reflectance from chromophores
+def CalculateReflectanceVsWavelengthFromChromophoreConcentration(
+    chromophoreConcentration, wavelengths, rho, scatterer, forwardSolver):
+# Create a forward solve model function to solve inverse
+   forwardSolverForInversion = PointSourceSDAForwardSolver()
+   # Create an array of chromophore absorbers based on values
+   chromophoresLocal = Array.CreateInstance(IChromophoreAbsorber, 3)
+   chromophoresLocal[0] = ChromophoreAbsorber(ChromophoreType.HbO2, chromophoreConcentration[0])
+   chromophoresLocal[1] = ChromophoreAbsorber(ChromophoreType.Hb, chromophoreConcentration[1])
+   chromophoresLocal[2] = ChromophoreAbsorber(ChromophoreType.H2O, chromophoreConcentration[2])
+   # Compose local tissue to obtain optical properties
+   opsLocal = Tissue(chromophoresLocal, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+   print('opsLocal[0]=',opsLocal[0])
+   # Compute reflectance for local absorbers
+   modelDataLocal = Array.CreateInstance(float, len(wavelengths))
+   modelDataLocal = forwardSolver.ROfRho(opsLocal, rho) 
+   modelDataForReturn= Array.CreateInstance(float, len(wavelengths))
+   for i in range(0, len(wavelengths)):
+        modelDataForReturn[i] = modelDataLocal[i]
+   print('modelDataForReturn[0]=',modelDataForReturn[0])
+   return modelDataForReturn
+
+# func for residual
+def residual(chromophoreConcentration, wavelengths, rho, scatterer, measuredData, forwardSolver):
+   prediction = CalculateReflectanceVsWavelengthFromChromophoreConcentration(
+      chromophoreConcentration, wavelengths, rho, scatterer, forwardSolver) 
+   difference = Array.CreateInstance(float,len(wavelengths))
+   for i in range(0,len(wavelengths)):
+       difference[i] = prediction[i] - measuredData[i]
+   return difference
+
+# Run the inversion: set up initial guess 
+initialGuess = [75.0, 25.0, 0.9]
+chromophoresInitialGuess = Array.CreateInstance(IChromophoreAbsorber, 3)
+chromophoresInitialGuess[0] = ChromophoreAbsorber(ChromophoreType.HbO2, initialGuess[0])
+chromophoresInitialGuess[1] = ChromophoreAbsorber(ChromophoreType.Hb, initialGuess[1])
+chromophoresInitialGuess[2] = ChromophoreAbsorber(ChromophoreType.H2O, initialGuess[2])
+# Compose tissue for initial guess data to obtain OPs
+opsInitialGuess = Tissue(chromophoresInitialGuess, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+# Run the levenberg-marquardt inversion
+from scipy.optimize import least_squares
+fit = least_squares(
+   residual,
+   initialGuess, 
+   ftol=1e-9, xtol=1e-9, max_nfev=10000, # max_nfev needs to be integer
+   args=(wavelengths, rho, scatterer, measuredData, forwardSolverForInversion), 
+   method='lm')
+print('fit.x=',fit.x)
+# Calculate final reflectance from model at fit values
+chromophoresFit = Array.CreateInstance(IChromophoreAbsorber, 3)
+chromophoresFit[0] = ChromophoreAbsorber(ChromophoreType.HbO2, fit.x[0])
+chromophoresFit[1] = ChromophoreAbsorber(ChromophoreType.Hb, fit.x[1])
+chromophoresFit[2] = ChromophoreAbsorber(ChromophoreType.H2O, fit.x[2])
+opsFit = Tissue(chromophoresFit, scatterer, "", n=1.4).GetOpticalProperties(wavelengths)
+fitReflectanceSpectrum = forwardSolverForInversion.ROfRho(opsFit, rho)
+# plot the results using Plotly
+xLabel = "wavelengths [nm]"
+yLabel = "R(wavelength) [mm-2]"
+wvs = [w for w in wavelengths]
+print('wvs[0]=',wvs[0])
+# plot measured data
+meas = [m for m in measuredData]
+chart = go.Figure()
+chart.add_trace(go.Scatter(x=wvs, y=meas, mode='markers', name='measured data'))
+# plot initial guess data
+initialGuessR = forwardSolverForInversion.ROfRho(opsInitialGuess, rho) 
+ig = [i for i in initialGuessR]
+chart.add_trace(go.Scatter(x=wvs, y=ig, mode='markers', name='initial guess'))
+# plot fit
+fit = [f for f in fitReflectanceSpectrum]
+chart.add_trace(go.Scatter(x=wvs, y=fit, mode='markers', name='fit'))
+chart.update_layout( title="R(wavelength) [mm-2]", xaxis_title=xLabel, yaxis_title=yLabel)
+chart.show(renderer="browser")
+
+
+
+
+
+
+


### PR DESCRIPTION
So far we have 3 inversion command line scripts:
1) R(rho) to find chromophore concentrations of [Hb HbO2 H2O], with fixed single rho=1mm, 13 wavelengths [400:50:1000]nm and scatterer Power Law coefficients A=1.2, b=1.42. Scaled Monte Carlo with Nurbs forward solver provides the simulated measured data and PointSourceSDA provides the model used during the inversion.
The optimization is performed by a python library scipy.
2) same as above but instead of python scipy optimize, the inversion is performed using Vts.MPFitLevenbergMarquardt.Solve method.
Currently 1) and 2) provide identical results
3) R(fx) to find chromophore concentrations [Hb HbO2] and power law coefficients [A b] using fixed fx=[0 0.2]/mm and wavelengths=[650:50:1000]nm.  Scaled Monte Carlo with Nurbs forward solver provides the simulated measured data and PointSourceSDA provides the model used during the inversion.
The optimization is performed by a python library scipy.
